### PR TITLE
Fixes issue where error pops up when sender_address has a whitespace

### DIFF
--- a/lib/oneapi-ruby/client.rb
+++ b/lib/oneapi-ruby/client.rb
@@ -98,7 +98,7 @@ module OneApi
 
         def execute_request(http_method, url, params)
             rest_url = get_rest_url(url)
-            uri = URI(rest_url)
+            uri = URI(URI.encode(rest_url))
 
             if Utils.empty(params)
                 params = {}


### PR DESCRIPTION
Just encoding the rest url fixes the issue.
